### PR TITLE
Disable CONFIG_BPF_PRELOAD_UMD to simplify cross-compiles

### DIFF
--- a/base.config
+++ b/base.config
@@ -51,3 +51,7 @@ CONFIG_FONT_TER16x32=y
 ## enable /proc/config.gz, used by linux-info.eclass
 CONFIG_IKCONFIG=y
 CONFIG_IKCONFIG_PROC=y
+
+## This breaks cross-compiles unless a cross-compiled libelf is available
+## https://bugs.gentoo.org/770430
+# CONFIG_BPF_PRELOAD_UMD is not set


### PR DESCRIPTION
Enabling this option requires a copy of libelf built for CHOST.
Rather than adding libelf to DEPEND in kernel ebuilds, disable this
option by default.

Bug: https://bugs.gentoo.org/770430