### PR TITLE
Add hardened config parts

### DIFF
--- a/hardened-amd64.config
+++ b/hardened-amd64.config
@@ -1,0 +1,21 @@
+## https://kernsec.org/wiki/index.php/Kernel_Self_Protection_Project/Recommended_Settings
+
+## Disallow allocating the first 64k of memory.
+CONFIG_DEFAULT_MMAP_MIN_ADDR=65536
+
+# Disable Model-Specific Register writes.
+# CONFIG_X86_MSR is not set
+
+## Randomize position of kernel and memory.
+CONFIG_RANDOMIZE_BASE=y
+CONFIG_RANDOMIZE_MEMORY=y
+
+## Modern libc no longer needs a fixed-position mapping in userspace, remove it as a possible target.
+CONFIG_LEGACY_VSYSCALL_NONE=y
+
+## Enable Kernel Page Table Isolation to remove an entire class of cache timing side-channels.
+CONFIG_PAGE_TABLE_ISOLATION=y
+
+## Remove additional attack surface, unless you really need them.
+# CONFIG_X86_X32 is not set
+# CONFIG_MODIFY_LDT_SYSCALL is not set

--- a/hardened-arm.config
+++ b/hardened-arm.config
@@ -1,0 +1,16 @@
+## https://kernsec.org/wiki/index.php/Kernel_Self_Protection_Project/Recommended_Settings
+
+## Disallow allocating the first 32k of memory (cannot be 64k due to ARM loader).
+CONFIG_DEFAULT_MMAP_MIN_ADDR=32768
+
+## For maximal userspace memory area (and maximum ASLR).
+CONFIG_VMSPLIT_3G=y
+
+## If building an old out-of-tree Qualcomm kernel, this is similar to CONFIG_STRICT_KERNEL_RWX.
+CONFIG_STRICT_MEMORY_RWX=y
+
+## Make sure PXN/PAN emulation is enabled.
+CONFIG_CPU_SW_DOMAIN_PAN=y
+
+## Dangerous; old interfaces and needless additional attack surface.
+# CONFIG_OABI_COMPAT is not set

--- a/hardened-arm64.config
+++ b/hardened-arm64.config
@@ -1,0 +1,11 @@
+## Disallow allocating the first 32k of memory (cannot be 64k due to ARM loader).
+CONFIG_DEFAULT_MMAP_MIN_ADDR=32768
+
+## Randomize position of kernel (requires UEFI RNG or bootloader support for /chosen/kaslr-seed DT property).
+CONFIG_RANDOMIZE_BASE=y
+
+## Make sure PAN emulation is enabled.
+CONFIG_ARM64_SW_TTBR0_PAN=y
+
+## Enable Kernel Page Table Isolation to remove an entire class of cache timing side-channels.
+CONFIG_UNMAP_KERNEL_AT_EL0=y

--- a/hardened-base.config
+++ b/hardened-base.config
@@ -1,0 +1,108 @@
+## taken from https://kernsec.org/wiki/index.php/Kernel_Self_Protection_Project/Recommended_Settings
+## and modified to suit our needs
+
+## Report BUG() conditions and kill the offending process.
+CONFIG_BUG=y
+
+## Make sure kernel page tables have safe permissions.
+CONFIG_STRICT_KERNEL_RWX=y
+
+## Report any dangerous memory permissions (not available on all archs).
+CONFIG_DEBUG_WX=y
+
+## Use -fstack-protector-strong (gcc 4.9+) for best stack canary coverage.
+CONFIG_STACKPROTECTOR=y
+CONFIG_STACKPROTECTOR_STRONG=y
+
+## Do not allow direct physical memory access (but if you must have it, at least enable STRICT mode...)
+CONFIG_STRICT_DEVMEM=y
+CONFIG_IO_STRICT_DEVMEM=y
+
+## Provides some protections against SYN flooding.
+CONFIG_SYN_COOKIES=y
+
+## Perform additional validation of various commonly targeted structures.
+CONFIG_DEBUG_CREDENTIALS=y
+CONFIG_DEBUG_NOTIFIERS=y
+CONFIG_DEBUG_LIST=y
+CONFIG_DEBUG_SG=y
+CONFIG_BUG_ON_DATA_CORRUPTION=y
+CONFIG_SCHED_STACK_END_CHECK=y
+
+## Provide userspace with seccomp BPF API for syscall attack surface reduction.
+CONFIG_SECCOMP=y
+CONFIG_SECCOMP_FILTER=y
+
+## Provide userspace with ptrace ancestry protections.
+CONFIG_SECURITY=y
+CONFIG_SECURITY_YAMA=y
+
+## Perform usercopy bounds checking. (And disable fallback to gain full whitelist enforcement.)
+CONFIG_HARDENED_USERCOPY=y
+# CONFIG_HARDENED_USERCOPY_FALLBACK is not set
+# CONFIG_HARDENED_USERCOPY_PAGESPAN is not set
+
+## Randomize allocator freelists, harden metadata.
+CONFIG_SLAB_FREELIST_RANDOM=y
+CONFIG_SLAB_FREELIST_HARDENED=y
+
+## Randomize high-order page allocation freelist.
+CONFIG_SHUFFLE_PAGE_ALLOCATOR=y
+
+## Allow allocator validation checking to be enabled (see "slub_debug=P" below).
+CONFIG_SLUB_DEBUG=y
+
+## Wipe higher-level memory allocations when they are freed (needs "page_poison=1" command line below).
+## (If you can afford even more performance penalty, leave CONFIG_PAGE_POISONING_NO_SANITY=n)
+CONFIG_PAGE_POISONING=y
+CONFIG_PAGE_POISONING_NO_SANITY=y
+CONFIG_PAGE_POISONING_ZERO=y
+
+## Wipe slab and page allocations (since v5.3)
+## Instead of "slub_debug=P" and "page_poison=1", a single place can control memory allocation wiping now.
+## The init_on_free is only needed if there is concern about minimizing stale data lifetime.
+CONFIG_INIT_ON_ALLOC_DEFAULT_ON=y
+CONFIG_INIT_ON_FREE_DEFAULT_ON=y
+
+## Adds guard pages to kernel stacks (not all architectures support this yet).
+CONFIG_VMAP_STACK=y
+
+## Perform extensive checks on reference counting.
+CONFIG_REFCOUNT_FULL=y
+
+## Check for memory copies that might overflow a structure in str*() and mem*() functions both at build-time and run-time.
+CONFIG_FORTIFY_SOURCE=y
+
+## Avoid kernel memory address exposures via dmesg (sets sysctl kernel.dmesg_restrict initial value to 1)
+CONFIG_SECURITY_DMESG_RESTRICT=y
+
+## Dangerous; enabling this allows direct physical memory writing.
+# CONFIG_ACPI_CUSTOM_METHOD is not set
+
+## Dangerous; enabling this disables brk ASLR.
+# CONFIG_COMPAT_BRK is not set
+
+## Dangerous; enabling this allows direct kernel memory writing.
+# CONFIG_DEVKMEM is not set
+
+## Dangerous; exposes kernel text image layout.
+# CONFIG_PROC_KCORE is not set
+
+## Dangerous; enabling this disables VDSO ASLR.
+# CONFIG_COMPAT_VDSO is not set
+
+## Dangerous; enabling this allows replacement of running kernel.
+# CONFIG_KEXEC is not set
+
+## Dangerous; enabling this allows replacement of running kernel.
+# CONFIG_HIBERNATION is not set
+
+## Use the modern PTY interface (devpts) only.
+# CONFIG_LEGACY_PTYS is not set
+
+## If SELinux can be disabled at runtime, the LSM structures cannot be read-only; keep off.
+# CONFIG_SECURITY_SELINUX_DISABLE is not set
+
+## Reboot devices immediately if kernel experiences an Oops.
+CONFIG_PANIC_ON_OOPS=y
+CONFIG_PANIC_TIMEOUT=-1

--- a/hardened-gcc-plugins.config
+++ b/hardened-gcc-plugins.config
@@ -1,0 +1,20 @@
+## https://kernsec.org/wiki/index.php/Kernel_Self_Protection_Project/Recommended_Settings
+
+## Enable GCC Plugins
+CONFIG_GCC_PLUGINS=y
+
+# Gather additional entropy at boot time for systems that may not have appropriate entropy sources.
+CONFIG_GCC_PLUGIN_LATENT_ENTROPY=y
+
+## Force all structures to be initialized before they are passed to other functions.
+## When building with GCC:
+CONFIG_GCC_PLUGIN_STRUCTLEAK=y
+CONFIG_GCC_PLUGIN_STRUCTLEAK_BYREF_ALL=y
+
+## Wipe stack contents on syscall exit (reduces stale data lifetime in stack)
+CONFIG_GCC_PLUGIN_STACKLEAK=y
+
+## Randomize the layout of system structures. This may have dramatic performance impact, so
+## use with caution or also use CONFIG_GCC_PLUGIN_RANDSTRUCT_PERFORMANCE=y
+CONFIG_GCC_PLUGIN_RANDSTRUCT=y
+CONFIG_GCC_PLUGIN_RANDSTRUCT_PERFORMANCE=y

--- a/hardened-x86.config
+++ b/hardened-x86.config
@@ -1,0 +1,22 @@
+## https://kernsec.org/wiki/index.php/Kernel_Self_Protection_Project/Recommended_Settings
+
+## On 32-bit kernels, require PAE for NX bit support.
+# CONFIG_M486 is not set
+# CONFIG_HIGHMEM4G is not set
+CONFIG_HIGHMEM64G=y
+CONFIG_X86_PAE=y
+
+## Disallow allocating the first 64k of memory.
+CONFIG_DEFAULT_MMAP_MIN_ADDR=65536
+
+## Disable Model-Specific Register writes.
+# CONFIG_X86_MSR is not set
+
+## Randomize position of kernel.
+CONFIG_RANDOMIZE_BASE=y
+
+## Enable Kernel Page Table Isolation to remove an entire class of cache timing side-channels.
+CONFIG_PAGE_TABLE_ISOLATION=y
+
+## Don't allow for 16-bit program emulation and associated LDT tricks.
+# CONFIG_MODIFY_LDT_SYSCALL is not set


### PR DESCRIPTION
from https://kernsec.org/wiki/index.php/Kernel_Self_Protection_Project/Recommended_Settings

will need a tag to use it in ebuilds, I suggest `v5.10.42`

I was thinking enabling it for 5.10 and 5.12, latest ebuilds only.

