### PR TITLE
base.config: enable CONFIG_ACPI_EXTLOG for app-admin/rasdaemon

### DIFF
--- a/base.config
+++ b/base.config
@@ -80,3 +80,6 @@ CONFIG_WIREGUARD=m
 ## https://bugs.gentoo.org/840439
 # CONFIG_DRM_SIMPLEDRM is not set
 # CONFIG_SYSFB_SIMPLEFB is not set
+
+## required for capturing memory error events for app-admin/rasdaemon
+CONFIG_ACPI_EXTLOG=m


### PR DESCRIPTION
Signed-off-by: David Seifert <soap@gentoo.org>