### PR TITLE
Enable XFS

### DIFF
--- a/base.config
+++ b/base.config
@@ -98,3 +98,10 @@ CONFIG_FB_VESA=y
 ## to help
 ## https://bugs.gentoo.org/897684
 CONFIG_EFI_ZBOOT=n
+
+## Enable XFS by default on all kernels
+## https://bugs.gentoo.org/915871
+CONFIG_XFS_FS=y
+CONFIG_XFS_SUPPORT_V4=y
+CONFIG_XFS_QUOTA=y
+CONFIG_XFS_POSIX_ACL=y


### PR DESCRIPTION
Enable XFS by default on all architectures now that the handbook recommends it.

Bug: https://bugs.gentoo.org/915871