### PR TITLE
base: disable CONFIG_N_GSM

### DIFF
--- a/base.config
+++ b/base.config
@@ -112,3 +112,7 @@ CONFIG_SPI_MEM=y
 CONFIG_SPI_INTEL=m
 CONFIG_SPI_INTEL_PCI=m
 CONFIG_SPI_INTEL_PLATFORM=m
+
+## Disable insecure module required by rather uncommon hardware, as suggested
+## by greg k-h in https://www.openwall.com/lists/oss-security/2024/04/17/1
+CONFIG_N_GSM=n


### PR DESCRIPTION
The module has a bad track record with regard to security, resulting in local privilege escalations (LPEs) and in the recommendation to disable it per default.

See also https://www.openwall.com/lists/oss-security/2024/04/10/18