### PR TITLE
no-debug.config: Explicitly set CONFIG_DEBUG_INFO_NONE=y for Linux 6.11

### DIFF
--- a/no-debug.config
+++ b/no-debug.config
@@ -1,6 +1,7 @@
 ## no-debug configuration file for Gentoo dist-kernels
 ## Disables features related to kernel debugging
 
+CONFIG_DEBUG_INFO_NONE=y
 # CONFIG_DEBUG_INFO is not set
 # CONFIG_DEBUG_INFO_BTF is not set
 # CONFIG_DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT is not set


### PR DESCRIPTION
I started to get "no space let on [tmpfs] device" build errors with `sys-kernel/vanilla-kernel-6.11.2`, and I have pinpointed the cause to be `CONFIG_DEBUG_INFO_DWARF4` being automatically set to `y` (which brought the build directory size up to more than 11 GiB):

```console
$ ls /etc/kernel/config.d
ls: cannot access '/etc/kernel/config.d': No such file or directory

$ emerge --info sys-kernel/vanilla-kernel
...
sys-kernel/vanilla-kernel-6.11.2::gentoo was built with the following:
USE="initramfs modules-sign secureboot strip -debug -hardened -savedconfig -test -verify-sig" ABI_X86="(64)"
...

$ USE="-modules-sign -secureboot" ebuild vanilla-kernel-6.11.2.ebuild clean configure
...
$ grep CONFIG_DEBUG_INFO /var/tmp/portage/sys-kernel/vanilla-kernel-6.11.2/work/build/.config
CONFIG_DEBUG_INFO=y
# CONFIG_DEBUG_INFO_NONE is not set
# CONFIG_DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT is not set
CONFIG_DEBUG_INFO_DWARF4=y
# CONFIG_DEBUG_INFO_DWARF5 is not set
# CONFIG_DEBUG_INFO_REDUCED is not set
CONFIG_DEBUG_INFO_COMPRESSED_NONE=y
# CONFIG_DEBUG_INFO_COMPRESSED_ZLIB is not set
# CONFIG_DEBUG_INFO_COMPRESSED_ZSTD is not set
# CONFIG_DEBUG_INFO_SPLIT is not set
# CONFIG_DEBUG_INFO_BTF is not set
```

However, with `sys-kernel/vanilla-kernel-6.10.13`, `CONFIG_DEBUG_INFO_DWARF4` won't be set to `y`:
```console
$ USE="-modules-sign -secureboot" ebuild vanilla-kernel-6.10.13.ebuild clean configure
...
$ grep CONFIG_DEBUG_INFO /var/tmp/portage/sys-kernel/vanilla-kernel-6.10.13/work/build/.config
CONFIG_DEBUG_INFO_NONE=y
# CONFIG_DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT is not set
# CONFIG_DEBUG_INFO_DWARF4 is not set
# CONFIG_DEBUG_INFO_DWARF5 is not set
```

I am not quite familiar with the Linux kernel build system and am not sure why exactly this is happening, but I am uploading `build.log` files for those two ebuilds if you want to investigate further:
- [vanilla-kernel-6.10.13.log](https://github.com/user-attachments/files/17267688/vanilla-kernel-6.10.13.log)
- [vanilla-kernel-6.11.2.log](https://github.com/user-attachments/files/17267690/vanilla-kernel-6.11.2.log)

Anyway, if I first just run `src_unpack` on `sys-kernel/vanilla-kernel-6.11.2`, then make the same change as the commit in this PR to `no-debug.config` extracted to `WORKDIR`, and then run `src_configure`, then 6.11.2 has the same behavior as 6.10.13 with regards to the `CONFIG_DEBUG_INFO_*` options.  Perhaps we should add `CONFIG_DEBUG_INFO_NONE=y` to `no-debug.config` for Linux 6.11 now?