### PR TITLE
base.config: enable all ZRAM backends

### DIFF
--- a/base.config
+++ b/base.config
@@ -116,3 +116,11 @@ CONFIG_SPI_INTEL_PLATFORM=m
 ## Disable insecure module required by rather uncommon hardware, as suggested
 ## by greg k-h in https://www.openwall.com/lists/oss-security/2024/04/17/1
 CONFIG_N_GSM=n
+
+## Enable all zram backends
+CONFIG_ZRAM_BACKEND_LZ4=y
+CONFIG_ZRAM_BACKEND_LZ4HC=y
+CONFIG_ZRAM_BACKEND_ZSTD=y
+CONFIG_ZRAM_BACKEND_DEFLATE=y
+CONFIG_ZRAM_BACKEND_842=y
+CONFIG_ZRAM_BACKEND_LZO=y


### PR DESCRIPTION
6.12+ has reworked how zram compression methods are configured[1]. Let's enable all supported backends so the user can choose their preferred one. `CONFIG_ZRAM_DEF_COMP` controls the default, we leave that untouched.

[1] https://lore.kernel.org/all/20240902105656.1383858-9-senozhatsky@chromium.org/T/#u

Closes: https://bugs.gentoo.org/946547