### PR TITLE
Add Vortex86 board support

### DIFF
--- a/x86.config
+++ b/x86.config
@@ -1,0 +1,4 @@
+## Enable support for Vortex86 boards
+CONFIG_PATA_RDC=y
+CONFIG_NET_VENDOR_RDC=y
+CONFIG_R6040=m


### PR DESCRIPTION
Vortex86 SoC use RDC based harware which isn't enabled on Fedora as their baseline doesn't support these boards. These changes will let Gentoo support the following stage3s on x86 https://wiki.gentoo.org/wiki/User:Immolo/ebox-3350dx3#Stage3 and any amd64 board that uses these chipset in the future.