### PR TITLE
6.12+.config: new file for XFS

### DIFF
--- a/6.12+.config
+++ b/6.12+.config
@@ -1,0 +1,9 @@
+# XFS extras
+# These are marked as experimental in the help text, but are considered
+# stable enough to have enabled. Tools warn on their use anyway and
+# e.g. systemd services that make use of them aren't enabled by default.
+#
+# https://blogs.oracle.com/linux/post/xfs-online-filesystem-checking
+# https://blogs.oracle.com/linux/post/xfs-online-filesystem-repair
+CONFIG_XFS_ONLINE_REPAIR=y
+CONFIG_XFS_ONLINE_SCRUB=y


### PR DESCRIPTION
Enable the following:
* CONFIG_XFS_ONLINE_REPAIR (https://blogs.oracle.com/linux/post/xfs-online-filesystem-repair)
* CONFIG_XFS_ONLINE_SCRUB (https://blogs.oracle.com/linux/post/xfs-online-filesystem-checking)

These are marked as experimental in the help text, but are considered stable enough to have enabled. Tools warn on their use anyway and e.g. systemd services that make use of them aren't enabled by default.

Doing this only for 6.12+ as repair is only available there and it's the latest LTS.

As for why we're doing this at all: we had a user who really wanted this functionality out of the box w/ gentoo-kernel-bin and was disappointed when passing the right flags to the xfs* tooling didn't let them use it. Given the upstream remarks on those blog posts, it seems reasonable to facilitate using it, especially since it's so convenient.

Looking at discussions on the ML (e.g. https://lore.kernel.org/linux-xfs/20240709225306.GE612460@frogsfrogsfrogs/), the only concerns anyone has are over turning on the systemd scrub services by default, not the functionality in the kernel.