### PR TITLE
base.config: enable landlock by default

### DIFF
--- a/base.config
+++ b/base.config
@@ -18,7 +18,7 @@ CONFIG_X86_X32_ABI=y
 ## remove massive array of LSMs
 # CONFIG_DEFAULT_SECURITY_SELINUX is not set
 CONFIG_DEFAULT_SECURITY_DAC=y
-CONFIG_LSM="yama"
+CONFIG_LSM="landlock,yama"
 
 ## these tests are really not necessary
 CONFIG_CRYPTO_MANAGER_DISABLE_TESTS=y

--- a/base.config
+++ b/base.config
@@ -18,7 +18,7 @@ CONFIG_X86_X32_ABI=y
 ## remove massive array of LSMs
 # CONFIG_DEFAULT_SECURITY_SELINUX is not set
 CONFIG_DEFAULT_SECURITY_DAC=y
-CONFIG_LSM="landlock,yama"
+CONFIG_LSM="landlock,yama,bpf"
 
 ## these tests are really not necessary
 CONFIG_CRYPTO_MANAGER_DISABLE_TESTS=y


### PR DESCRIPTION
xz supports this and dmesg gives noise when something tries to use landlock but it isn't enabled.

Bug: https://bugs.gentoo.org/951870