### PR TITLE
base.config: enable CONFIG_TMPFS_INODE64=y

### DIFF
--- a/base.config
+++ b/base.config
@@ -125,6 +125,9 @@ CONFIG_ZRAM_BACKEND_DEFLATE=y
 CONFIG_ZRAM_BACKEND_842=y
 CONFIG_ZRAM_BACKEND_LZO=y
 
+## https://chrisdown.name/2021/07/02/tmpfs-inode-corruption-introducing-inode64.html
+CONFIG_TMPFS_INODE64=y
+
 # CONFIG_WERROR is not set
 # CONFIG_KVM_WERROR is not set
 # CONFIG_DRM_AMDGPU_WERROR is not set


### PR DESCRIPTION
https://chrisdown.name/2021/07/02/tmpfs-inode-corruption-introducing-inode64.html describes it well. Avoid corruption from wraparound by using 64-bit inodes for tmpfs by default.

I don't expect non-LFS 32-bit compat to be much of a problem in practice given both xfs and btrfs use 64-bit inodes. If issues arise, we can compromise and set it only for amd64, but in theory you'd still have the issue with ancient 32-bit binaries. Note that `inode32` can be used as a mount option if required.

Another option would be to restore 32-bit.config (09c2d54aeef4f4e010f0a4fc84bc6ad137488408)
and disable it there.

I thought this was already the upstream default quite a long time ago and was surprised to see it wasn't.