### PR TITLE
Unset MOD SIGN and COMPRESS

### DIFF
--- a/base.config
+++ b/base.config
@@ -136,3 +136,12 @@ CONFIG_TMPFS_INODE64=y
 ## https://bugs.gentoo.org/782754
 CONFIG_NVME_CORE=y
 CONFIG_BLK_DEV_NVME=y
+
+## Debian sets module signing and compression on by default
+## Gentoo allows users to decide the feature using USE flags
+## so unset here to reallow that ability.
+CONFIG_SYSTEM_TRUSTED_KEYS=""
+CONFIG_SYSTEM_REVOCATION_KEYS=""
+CONFIG_MODULE_SIG=n
+CONFIG_MODULE_SIG_ALL=n
+CONFIG_MODULE_COMPRESS_NONE=y


### PR DESCRIPTION
Debian sets module signing and compression on by default Gentoo allows users to decide the feature using USE flags so unset here to reallow that ability.